### PR TITLE
Add ndcalc-core: Calculus VM with bytecode, AD, and WASM

### DIFF
--- a/ndcalc-core/CMakeLists.txt
+++ b/ndcalc-core/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.20)
+project(ndcalc-core VERSION 0.1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Library sources
+set(NDCALC_SOURCES
+    src/parser.cpp
+    src/bytecode.cpp
+    src/vm.cpp
+    src/autodiff.cpp
+    src/finite_diff.cpp
+    src/api.cpp
+)
+
+# Main library
+add_library(ndcalc STATIC ${NDCALC_SOURCES})
+target_include_directories(ndcalc PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+# Compiler warnings
+if(MSVC)
+    target_compile_options(ndcalc PRIVATE /W4)
+else()
+    target_compile_options(ndcalc PRIVATE -Wall -Wextra -pedantic)
+endif()
+
+# Native tests
+option(NDCALC_BUILD_TESTS "Build native tests" ON)
+if(NDCALC_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
+# WASM build
+option(NDCALC_BUILD_WASM "Build WASM module" OFF)
+if(NDCALC_BUILD_WASM)
+    add_subdirectory(wasm)
+endif()

--- a/ndcalc-core/README.md
+++ b/ndcalc-core/README.md
@@ -1,0 +1,119 @@
+# ndcalc-core
+
+n-dimensional calculus VM with automatic differentiation and WASM support.
+
+## Features
+
+- **Expression Parser**: Recursive descent parser supporting variables, operators, and mathematical functions
+- **Bytecode VM**: Stack-based virtual machine for efficient expression evaluation
+- **Automatic Differentiation**: Forward-mode AD for exact gradient and Hessian computation
+- **Finite Differences**: Fallback numerical differentiation with configurable epsilon
+- **Batch Evaluation**: SoA (Structure-of-Arrays) support for efficient multi-point evaluation
+- **C API**: Clean C interface for native integration
+- **WASM Export**: Full WASM module with TypeScript declarations
+
+## Building
+
+### Native (with tests)
+
+```bash
+mkdir build
+cd build
+cmake .. -DNDCALC_BUILD_TESTS=ON
+make -j
+ctest
+```
+
+### WASM
+
+Requires Emscripten SDK:
+
+```bash
+cd wasm
+./build.sh
+```
+
+Output: `wasm/dist/ndcalc_wasm.{js,wasm}` and TypeScript declarations.
+
+## API Overview
+
+### C API
+
+```c
+#include <ndcalc/api.h>
+
+// Create context
+ndcalc_context_handle ctx = ndcalc_context_create();
+
+// Compile expression
+const char* vars[] = {"x", "y"};
+ndcalc_program_handle program;
+ndcalc_compile(ctx, "x^2 + y^2", 2, vars, &program);
+
+// Evaluate
+double inputs[] = {3.0, 4.0};
+double result;
+ndcalc_eval(program, inputs, 2, &result);
+
+// Compute gradient
+double gradient[2];
+ndcalc_gradient(program, inputs, 2, gradient);
+
+// Cleanup
+ndcalc_program_destroy(program);
+ndcalc_context_destroy(ctx);
+```
+
+### TypeScript (WASM)
+
+```typescript
+import createNdcalcModule from './dist/index.js';
+
+const ndcalc = await createNdcalcModule();
+
+const ctx = ndcalc.contextCreate();
+const [err, program] = ndcalc.compile(ctx, "x^2 + y^2", ["x", "y"]);
+
+if (err === 0) {
+  const [evalErr, result] = ndcalc.eval(program, [3.0, 4.0]);
+  console.log("f(3,4) =", result); // 25
+
+  const [gradErr, grad] = ndcalc.gradient(program, [3.0, 4.0]);
+  console.log("∇f =", grad); // [6.0, 8.0]
+
+  ndcalc.programDestroy(program);
+}
+
+ndcalc.contextDestroy(ctx);
+```
+
+## Supported Operations
+
+### Operators
+- Arithmetic: `+`, `-`, `*`, `/`, `^`
+- Unary: `-` (negation)
+
+### Functions
+- Trigonometric: `sin`, `cos`, `tan`
+- Exponential: `exp`, `log`, `sqrt`
+- Other: `abs`, `pow`
+
+## Architecture
+
+1. **Parser** (`parser.cpp`): Tokenizes and builds AST from expression string
+2. **Compiler** (`compiler.cpp`): Converts AST to bytecode instructions
+3. **VM** (`vm.cpp`): Executes bytecode with double precision
+4. **AutoDiff** (`autodiff.cpp`): Forward-mode AD using dual numbers
+5. **FiniteDiff** (`finite_diff.cpp`): Central differences fallback
+6. **API** (`api.cpp`): C interface wrapping internal components
+
+## Integration with HyperViz
+
+ndcalc-core provides:
+- User-defined scalar/vector field evaluation
+- Gradient computation for tangent plane visualization
+- Hessian for curvature analysis
+- Batch evaluation for level-set tracing
+- Zero-copy WASM interface for browser integration
+
+See `docs/integration-plan.md` in parent repository for full integration details.

--- a/ndcalc-core/include/ndcalc/api.h
+++ b/ndcalc-core/include/ndcalc/api.h
@@ -1,0 +1,92 @@
+#ifndef NDCALC_API_H
+#define NDCALC_API_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+// Error codes
+typedef enum {
+    NDCALC_OK = 0,
+    NDCALC_ERROR_PARSE = 1,
+    NDCALC_ERROR_INVALID_EXPR = 2,
+    NDCALC_ERROR_EVAL = 3,
+    NDCALC_ERROR_OUT_OF_MEMORY = 4,
+    NDCALC_ERROR_INVALID_DIMENSION = 5,
+    NDCALC_ERROR_NULL_POINTER = 6
+} ndcalc_error_t;
+
+// Opaque handle types
+typedef struct ndcalc_program_t* ndcalc_program_handle;
+typedef struct ndcalc_context_t* ndcalc_context_handle;
+
+// Context management
+ndcalc_context_handle ndcalc_context_create(void);
+void ndcalc_context_destroy(ndcalc_context_handle ctx);
+
+// Program compilation
+ndcalc_error_t ndcalc_compile(
+    ndcalc_context_handle ctx,
+    const char* expression,
+    size_t num_variables,
+    const char* const* variable_names,
+    ndcalc_program_handle* out_program
+);
+
+void ndcalc_program_destroy(ndcalc_program_handle program);
+
+// Evaluation
+ndcalc_error_t ndcalc_eval(
+    ndcalc_program_handle program,
+    const double* inputs,
+    size_t num_inputs,
+    double* output
+);
+
+// Batch evaluation (SoA)
+ndcalc_error_t ndcalc_eval_batch(
+    ndcalc_program_handle program,
+    const double* const* input_arrays,  // array of pointers to input arrays
+    size_t num_variables,
+    size_t num_points,
+    double* output_array
+);
+
+// Gradient computation (forward-mode AD)
+ndcalc_error_t ndcalc_gradient(
+    ndcalc_program_handle program,
+    const double* inputs,
+    size_t num_inputs,
+    double* gradient_out
+);
+
+// Hessian computation
+ndcalc_error_t ndcalc_hessian(
+    ndcalc_program_handle program,
+    const double* inputs,
+    size_t num_inputs,
+    double* hessian_out  // row-major, size = num_inputs * num_inputs
+);
+
+// Finite-difference fallback configuration
+typedef enum {
+    NDCALC_AD_MODE_AUTO = 0,     // Use AD when possible, fallback to FD
+    NDCALC_AD_MODE_FORWARD = 1,  // Force forward-mode AD
+    NDCALC_AD_MODE_FINITE_DIFF = 2  // Force finite differences
+} ndcalc_ad_mode_t;
+
+void ndcalc_set_ad_mode(ndcalc_context_handle ctx, ndcalc_ad_mode_t mode);
+void ndcalc_set_fd_epsilon(ndcalc_context_handle ctx, double epsilon);
+
+// Error handling
+const char* ndcalc_error_string(ndcalc_error_t error);
+const char* ndcalc_get_last_error_message(ndcalc_context_handle ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NDCALC_API_H

--- a/ndcalc-core/include/ndcalc/autodiff.h
+++ b/ndcalc-core/include/ndcalc/autodiff.h
@@ -1,0 +1,80 @@
+#ifndef NDCALC_AUTODIFF_H
+#define NDCALC_AUTODIFF_H
+
+#include "bytecode.h"
+#include <vector>
+
+namespace ndcalc {
+
+// Dual number for forward-mode AD
+struct Dual {
+    double value;      // Primal value
+    double derivative; // Tangent value
+
+    Dual(double v = 0.0, double d = 0.0) : value(v), derivative(d) {}
+
+    Dual operator+(const Dual& other) const {
+        return Dual(value + other.value, derivative + other.derivative);
+    }
+
+    Dual operator-(const Dual& other) const {
+        return Dual(value - other.value, derivative - other.derivative);
+    }
+
+    Dual operator*(const Dual& other) const {
+        return Dual(value * other.value,
+                   derivative * other.value + value * other.derivative);
+    }
+
+    Dual operator/(const Dual& other) const {
+        return Dual(value / other.value,
+                   (derivative * other.value - value * other.derivative) /
+                   (other.value * other.value));
+    }
+
+    Dual operator-() const {
+        return Dual(-value, -derivative);
+    }
+};
+
+// Mathematical functions for dual numbers
+Dual dual_sin(const Dual& x);
+Dual dual_cos(const Dual& x);
+Dual dual_tan(const Dual& x);
+Dual dual_exp(const Dual& x);
+Dual dual_log(const Dual& x);
+Dual dual_sqrt(const Dual& x);
+Dual dual_abs(const Dual& x);
+Dual dual_pow(const Dual& x, const Dual& y);
+
+class AutoDiff {
+public:
+    AutoDiff();
+
+    // Compute gradient using forward-mode AD
+    bool compute_gradient(const BytecodeProgram& program,
+                          const double* inputs,
+                          size_t num_inputs,
+                          double* gradient);
+
+    // Compute Hessian using nested forward-mode AD
+    bool compute_hessian(const BytecodeProgram& program,
+                         const double* inputs,
+                         size_t num_inputs,
+                         double* hessian);
+
+    const std::string& get_error() const { return error_message_; }
+
+private:
+    std::vector<Dual> stack_;
+    std::string error_message_;
+
+    bool execute_dual(const BytecodeProgram& program,
+                      const Dual* inputs,
+                      size_t num_inputs,
+                      Dual& result);
+};
+
+} // namespace ndcalc
+
+#endif // NDCALC_AUTODIFF_H

--- a/ndcalc-core/include/ndcalc/bytecode.h
+++ b/ndcalc-core/include/ndcalc/bytecode.h
@@ -1,0 +1,69 @@
+#ifndef NDCALC_BYTECODE_H
+#define NDCALC_BYTECODE_H
+
+#include <vector>
+#include <cstdint>
+#include <string>
+
+namespace ndcalc {
+
+// Bytecode operations
+enum class OpCode : uint8_t {
+    // Stack operations
+    PUSH_CONST,      // Push constant value
+    LOAD_VAR,        // Load variable by index
+
+    // Arithmetic
+    ADD,
+    SUB,
+    MUL,
+    DIV,
+    NEG,
+    POW,
+
+    // Mathematical functions
+    SIN,
+    COS,
+    TAN,
+    EXP,
+    LOG,
+    SQRT,
+    ABS,
+
+    // Control
+    RETURN
+};
+
+struct Instruction {
+    OpCode opcode;
+    union {
+        double const_value;
+        size_t var_index;
+        size_t arg_count;
+    } operand;
+
+    Instruction(OpCode op) : opcode(op) { operand.const_value = 0.0; }
+    Instruction(OpCode op, double value) : opcode(op) { operand.const_value = value; }
+    Instruction(OpCode op, size_t index) : opcode(op) { operand.var_index = index; }
+};
+
+class BytecodeProgram {
+public:
+    BytecodeProgram() = default;
+
+    void add_instruction(const Instruction& inst);
+    const std::vector<Instruction>& instructions() const { return instructions_; }
+
+    void set_num_variables(size_t n) { num_variables_ = n; }
+    size_t num_variables() const { return num_variables_; }
+
+    std::string disassemble() const;
+
+private:
+    std::vector<Instruction> instructions_;
+    size_t num_variables_ = 0;
+};
+
+} // namespace ndcalc
+
+#endif // NDCALC_BYTECODE_H

--- a/ndcalc-core/include/ndcalc/compiler.h
+++ b/ndcalc-core/include/ndcalc/compiler.h
@@ -1,0 +1,27 @@
+#ifndef NDCALC_COMPILER_H
+#define NDCALC_COMPILER_H
+
+#include "parser.h"
+#include "bytecode.h"
+#include <memory>
+
+namespace ndcalc {
+
+class Compiler {
+public:
+    Compiler();
+
+    // Compile AST to bytecode
+    std::unique_ptr<BytecodeProgram> compile(const ASTNode& ast);
+
+    const std::string& get_error() const { return error_message_; }
+
+private:
+    void compile_node(const ASTNode& node, BytecodeProgram& program);
+
+    std::string error_message_;
+};
+
+} // namespace ndcalc
+
+#endif // NDCALC_COMPILER_H

--- a/ndcalc-core/include/ndcalc/finite_diff.h
+++ b/ndcalc-core/include/ndcalc/finite_diff.h
@@ -1,0 +1,40 @@
+#ifndef NDCALC_FINITE_DIFF_H
+#define NDCALC_FINITE_DIFF_H
+
+#include "bytecode.h"
+#include "vm.h"
+#include <vector>
+
+namespace ndcalc {
+
+class FiniteDiff {
+public:
+    FiniteDiff(double epsilon = 1e-8);
+
+    // Compute gradient using central differences
+    bool compute_gradient(const BytecodeProgram& program,
+                          VM& vm,
+                          const double* inputs,
+                          size_t num_inputs,
+                          double* gradient);
+
+    // Compute Hessian using finite differences
+    bool compute_hessian(const BytecodeProgram& program,
+                         VM& vm,
+                         const double* inputs,
+                         size_t num_inputs,
+                         double* hessian);
+
+    void set_epsilon(double eps) { epsilon_ = eps; }
+    double get_epsilon() const { return epsilon_; }
+
+    const std::string& get_error() const { return error_message_; }
+
+private:
+    double epsilon_;
+    std::string error_message_;
+};
+
+} // namespace ndcalc
+
+#endif // NDCALC_FINITE_DIFF_H

--- a/ndcalc-core/include/ndcalc/parser.h
+++ b/ndcalc-core/include/ndcalc/parser.h
@@ -1,0 +1,71 @@
+#ifndef NDCALC_PARSER_H
+#define NDCALC_PARSER_H
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <unordered_map>
+
+namespace ndcalc {
+
+// Token types
+enum class TokenType {
+    NUMBER,
+    VARIABLE,
+    OPERATOR,
+    LPAREN,
+    RPAREN,
+    COMMA,
+    FUNCTION,
+    END
+};
+
+struct Token {
+    TokenType type;
+    std::string value;
+    size_t position;
+};
+
+// AST node types
+enum class ASTNodeType {
+    NUMBER,
+    VARIABLE,
+    BINARY_OP,
+    UNARY_OP,
+    FUNCTION_CALL
+};
+
+struct ASTNode {
+    ASTNodeType type;
+    std::string value;
+    std::vector<std::unique_ptr<ASTNode>> children;
+
+    ASTNode(ASTNodeType t, std::string v = "") : type(t), value(std::move(v)) {}
+};
+
+class Parser {
+public:
+    Parser();
+
+    // Parse expression into AST
+    std::unique_ptr<ASTNode> parse(const std::string& expression,
+                                     const std::vector<std::string>& variables);
+
+    // Get error message if parsing failed
+    const std::string& get_error() const { return error_message_; }
+
+private:
+    std::vector<Token> tokenize(const std::string& expression);
+    std::unique_ptr<ASTNode> parse_expression(size_t& pos);
+    std::unique_ptr<ASTNode> parse_term(size_t& pos);
+    std::unique_ptr<ASTNode> parse_factor(size_t& pos);
+    std::unique_ptr<ASTNode> parse_primary(size_t& pos);
+
+    std::vector<Token> tokens_;
+    std::unordered_map<std::string, size_t> variable_indices_;
+    std::string error_message_;
+};
+
+} // namespace ndcalc
+
+#endif // NDCALC_PARSER_H

--- a/ndcalc-core/include/ndcalc/vm.h
+++ b/ndcalc-core/include/ndcalc/vm.h
@@ -1,0 +1,39 @@
+#ifndef NDCALC_VM_H
+#define NDCALC_VM_H
+
+#include "bytecode.h"
+#include <vector>
+#include <string>
+
+namespace ndcalc {
+
+class VM {
+public:
+    VM();
+
+    // Execute program with given inputs
+    bool execute(const BytecodeProgram& program,
+                 const double* inputs,
+                 size_t num_inputs,
+                 double& result);
+
+    // Batch execution (SoA)
+    bool execute_batch(const BytecodeProgram& program,
+                       const double* const* input_arrays,
+                       size_t num_variables,
+                       size_t num_points,
+                       double* output_array);
+
+    const std::string& get_error() const { return error_message_; }
+
+private:
+    std::vector<double> stack_;
+    std::string error_message_;
+
+    void clear_error() { error_message_.clear(); }
+    void set_error(const std::string& msg) { error_message_ = msg; }
+};
+
+} // namespace ndcalc
+
+#endif // NDCALC_VM_H

--- a/ndcalc-core/src/api.cpp
+++ b/ndcalc-core/src/api.cpp
@@ -1,0 +1,222 @@
+#include "ndcalc/api.h"
+#include "ndcalc/parser.h"
+#include "ndcalc/compiler.h"
+#include "ndcalc/bytecode.h"
+#include "ndcalc/vm.h"
+#include "ndcalc/autodiff.h"
+#include "ndcalc/finite_diff.h"
+#include <memory>
+#include <string>
+#include <vector>
+
+struct ndcalc_context_t {
+    std::string last_error;
+    ndcalc_ad_mode_t ad_mode;
+    double fd_epsilon;
+
+    ndcalc_context_t()
+        : ad_mode(NDCALC_AD_MODE_AUTO), fd_epsilon(1e-8) {}
+};
+
+struct ndcalc_program_t {
+    std::unique_ptr<ndcalc::BytecodeProgram> bytecode;
+    ndcalc::VM vm;
+    ndcalc::AutoDiff autodiff;
+    ndcalc::FiniteDiff finite_diff;
+
+    ndcalc_program_t() : finite_diff(1e-8) {}
+};
+
+// Context management
+ndcalc_context_handle ndcalc_context_create(void) {
+    return new ndcalc_context_t();
+}
+
+void ndcalc_context_destroy(ndcalc_context_handle ctx) {
+    delete ctx;
+}
+
+// Program compilation
+ndcalc_error_t ndcalc_compile(
+    ndcalc_context_handle ctx,
+    const char* expression,
+    size_t num_variables,
+    const char* const* variable_names,
+    ndcalc_program_handle* out_program) {
+
+    if (!ctx || !expression || !variable_names || !out_program) {
+        if (ctx) ctx->last_error = "Null pointer argument";
+        return NDCALC_ERROR_NULL_POINTER;
+    }
+
+    try {
+        // Parse expression
+        ndcalc::Parser parser;
+        std::vector<std::string> vars;
+        for (size_t i = 0; i < num_variables; ++i) {
+            vars.push_back(variable_names[i]);
+        }
+
+        auto ast = parser.parse(expression, vars);
+        if (!ast) {
+            ctx->last_error = parser.get_error();
+            return NDCALC_ERROR_PARSE;
+        }
+
+        // Compile to bytecode
+        ndcalc::Compiler compiler;
+        auto bytecode = compiler.compile(*ast);
+        if (!bytecode) {
+            ctx->last_error = compiler.get_error();
+            return NDCALC_ERROR_INVALID_EXPR;
+        }
+
+        bytecode->set_num_variables(num_variables);
+
+        // Create program
+        auto program = new ndcalc_program_t();
+        program->bytecode = std::move(bytecode);
+        program->finite_diff.set_epsilon(ctx->fd_epsilon);
+
+        *out_program = program;
+        return NDCALC_OK;
+
+    } catch (const std::exception& e) {
+        ctx->last_error = e.what();
+        return NDCALC_ERROR_INVALID_EXPR;
+    }
+}
+
+void ndcalc_program_destroy(ndcalc_program_handle program) {
+    delete program;
+}
+
+// Evaluation
+ndcalc_error_t ndcalc_eval(
+    ndcalc_program_handle program,
+    const double* inputs,
+    size_t num_inputs,
+    double* output) {
+
+    if (!program || !inputs || !output) {
+        return NDCALC_ERROR_NULL_POINTER;
+    }
+
+    if (!program->vm.execute(*program->bytecode, inputs, num_inputs, *output)) {
+        return NDCALC_ERROR_EVAL;
+    }
+
+    return NDCALC_OK;
+}
+
+// Batch evaluation
+ndcalc_error_t ndcalc_eval_batch(
+    ndcalc_program_handle program,
+    const double* const* input_arrays,
+    size_t num_variables,
+    size_t num_points,
+    double* output_array) {
+
+    if (!program || !input_arrays || !output_array) {
+        return NDCALC_ERROR_NULL_POINTER;
+    }
+
+    if (!program->vm.execute_batch(*program->bytecode, input_arrays,
+                                    num_variables, num_points, output_array)) {
+        return NDCALC_ERROR_EVAL;
+    }
+
+    return NDCALC_OK;
+}
+
+// Gradient computation
+ndcalc_error_t ndcalc_gradient(
+    ndcalc_program_handle program,
+    const double* inputs,
+    size_t num_inputs,
+    double* gradient_out) {
+
+    if (!program || !inputs || !gradient_out) {
+        return NDCALC_ERROR_NULL_POINTER;
+    }
+
+    // Try automatic differentiation first
+    if (program->autodiff.compute_gradient(*program->bytecode, inputs,
+                                            num_inputs, gradient_out)) {
+        return NDCALC_OK;
+    }
+
+    // Fallback to finite differences
+    if (program->finite_diff.compute_gradient(*program->bytecode, program->vm,
+                                               inputs, num_inputs, gradient_out)) {
+        return NDCALC_OK;
+    }
+
+    return NDCALC_ERROR_EVAL;
+}
+
+// Hessian computation
+ndcalc_error_t ndcalc_hessian(
+    ndcalc_program_handle program,
+    const double* inputs,
+    size_t num_inputs,
+    double* hessian_out) {
+
+    if (!program || !inputs || !hessian_out) {
+        return NDCALC_ERROR_NULL_POINTER;
+    }
+
+    // Try automatic differentiation first
+    if (program->autodiff.compute_hessian(*program->bytecode, inputs,
+                                           num_inputs, hessian_out)) {
+        return NDCALC_OK;
+    }
+
+    // Fallback to finite differences
+    if (program->finite_diff.compute_hessian(*program->bytecode, program->vm,
+                                              inputs, num_inputs, hessian_out)) {
+        return NDCALC_OK;
+    }
+
+    return NDCALC_ERROR_EVAL;
+}
+
+// Configuration
+void ndcalc_set_ad_mode(ndcalc_context_handle ctx, ndcalc_ad_mode_t mode) {
+    if (ctx) {
+        ctx->ad_mode = mode;
+    }
+}
+
+void ndcalc_set_fd_epsilon(ndcalc_context_handle ctx, double epsilon) {
+    if (ctx) {
+        ctx->fd_epsilon = epsilon;
+    }
+}
+
+// Error handling
+const char* ndcalc_error_string(ndcalc_error_t error) {
+    switch (error) {
+        case NDCALC_OK:
+            return "Success";
+        case NDCALC_ERROR_PARSE:
+            return "Parse error";
+        case NDCALC_ERROR_INVALID_EXPR:
+            return "Invalid expression";
+        case NDCALC_ERROR_EVAL:
+            return "Evaluation error";
+        case NDCALC_ERROR_OUT_OF_MEMORY:
+            return "Out of memory";
+        case NDCALC_ERROR_INVALID_DIMENSION:
+            return "Invalid dimension";
+        case NDCALC_ERROR_NULL_POINTER:
+            return "Null pointer";
+        default:
+            return "Unknown error";
+    }
+}
+
+const char* ndcalc_get_last_error_message(ndcalc_context_handle ctx) {
+    if (!ctx) return "Invalid context";
+    return ctx->last_error.c_str();
+}

--- a/ndcalc-core/src/autodiff.cpp
+++ b/ndcalc-core/src/autodiff.cpp
@@ -1,0 +1,311 @@
+#include "ndcalc/autodiff.h"
+#include <cmath>
+#include <limits>
+
+namespace ndcalc {
+
+// Mathematical functions for dual numbers
+Dual dual_sin(const Dual& x) {
+    return Dual(std::sin(x.value), x.derivative * std::cos(x.value));
+}
+
+Dual dual_cos(const Dual& x) {
+    return Dual(std::cos(x.value), -x.derivative * std::sin(x.value));
+}
+
+Dual dual_tan(const Dual& x) {
+    double t = std::tan(x.value);
+    return Dual(t, x.derivative * (1.0 + t * t));
+}
+
+Dual dual_exp(const Dual& x) {
+    double e = std::exp(x.value);
+    return Dual(e, x.derivative * e);
+}
+
+Dual dual_log(const Dual& x) {
+    return Dual(std::log(x.value), x.derivative / x.value);
+}
+
+Dual dual_sqrt(const Dual& x) {
+    double s = std::sqrt(x.value);
+    return Dual(s, x.derivative / (2.0 * s));
+}
+
+Dual dual_abs(const Dual& x) {
+    if (x.value >= 0.0) {
+        return Dual(x.value, x.derivative);
+    } else {
+        return Dual(-x.value, -x.derivative);
+    }
+}
+
+Dual dual_pow(const Dual& x, const Dual& y) {
+    // d/dx[f^g] = f^g * (g' * ln(f) + g * f'/f)
+    double pow_val = std::pow(x.value, y.value);
+    double deriv = pow_val * (y.derivative * std::log(x.value) +
+                              y.value * x.derivative / x.value);
+    return Dual(pow_val, deriv);
+}
+
+AutoDiff::AutoDiff() {
+    stack_.reserve(256);
+}
+
+bool AutoDiff::execute_dual(const BytecodeProgram& program,
+                             const Dual* inputs,
+                             size_t num_inputs,
+                             Dual& result) {
+    stack_.clear();
+
+    if (num_inputs != program.num_variables()) {
+        error_message_ = "Input count mismatch";
+        return false;
+    }
+
+    for (const auto& inst : program.instructions()) {
+        switch (inst.opcode) {
+            case OpCode::PUSH_CONST:
+                stack_.push_back(Dual(inst.operand.const_value, 0.0));
+                break;
+
+            case OpCode::LOAD_VAR: {
+                size_t idx = inst.operand.var_index;
+                if (idx >= num_inputs) {
+                    error_message_ = "Variable index out of bounds";
+                    return false;
+                }
+                stack_.push_back(inputs[idx]);
+                break;
+            }
+
+            case OpCode::ADD: {
+                if (stack_.size() < 2) {
+                    error_message_ = "Stack underflow in ADD";
+                    return false;
+                }
+                Dual b = stack_.back(); stack_.pop_back();
+                Dual a = stack_.back(); stack_.pop_back();
+                stack_.push_back(a + b);
+                break;
+            }
+
+            case OpCode::SUB: {
+                if (stack_.size() < 2) {
+                    error_message_ = "Stack underflow in SUB";
+                    return false;
+                }
+                Dual b = stack_.back(); stack_.pop_back();
+                Dual a = stack_.back(); stack_.pop_back();
+                stack_.push_back(a - b);
+                break;
+            }
+
+            case OpCode::MUL: {
+                if (stack_.size() < 2) {
+                    error_message_ = "Stack underflow in MUL";
+                    return false;
+                }
+                Dual b = stack_.back(); stack_.pop_back();
+                Dual a = stack_.back(); stack_.pop_back();
+                stack_.push_back(a * b);
+                break;
+            }
+
+            case OpCode::DIV: {
+                if (stack_.size() < 2) {
+                    error_message_ = "Stack underflow in DIV";
+                    return false;
+                }
+                Dual b = stack_.back(); stack_.pop_back();
+                Dual a = stack_.back(); stack_.pop_back();
+                if (b.value == 0.0) {
+                    error_message_ = "Division by zero";
+                    return false;
+                }
+                stack_.push_back(a / b);
+                break;
+            }
+
+            case OpCode::NEG: {
+                if (stack_.empty()) {
+                    error_message_ = "Stack underflow in NEG";
+                    return false;
+                }
+                stack_.back() = -stack_.back();
+                break;
+            }
+
+            case OpCode::POW: {
+                if (stack_.size() < 2) {
+                    error_message_ = "Stack underflow in POW";
+                    return false;
+                }
+                Dual b = stack_.back(); stack_.pop_back();
+                Dual a = stack_.back(); stack_.pop_back();
+                stack_.push_back(dual_pow(a, b));
+                break;
+            }
+
+            case OpCode::SIN: {
+                if (stack_.empty()) {
+                    error_message_ = "Stack underflow in SIN";
+                    return false;
+                }
+                stack_.back() = dual_sin(stack_.back());
+                break;
+            }
+
+            case OpCode::COS: {
+                if (stack_.empty()) {
+                    error_message_ = "Stack underflow in COS";
+                    return false;
+                }
+                stack_.back() = dual_cos(stack_.back());
+                break;
+            }
+
+            case OpCode::TAN: {
+                if (stack_.empty()) {
+                    error_message_ = "Stack underflow in TAN";
+                    return false;
+                }
+                stack_.back() = dual_tan(stack_.back());
+                break;
+            }
+
+            case OpCode::EXP: {
+                if (stack_.empty()) {
+                    error_message_ = "Stack underflow in EXP";
+                    return false;
+                }
+                stack_.back() = dual_exp(stack_.back());
+                break;
+            }
+
+            case OpCode::LOG: {
+                if (stack_.empty()) {
+                    error_message_ = "Stack underflow in LOG";
+                    return false;
+                }
+                if (stack_.back().value <= 0.0) {
+                    error_message_ = "Logarithm of non-positive number";
+                    return false;
+                }
+                stack_.back() = dual_log(stack_.back());
+                break;
+            }
+
+            case OpCode::SQRT: {
+                if (stack_.empty()) {
+                    error_message_ = "Stack underflow in SQRT";
+                    return false;
+                }
+                if (stack_.back().value < 0.0) {
+                    error_message_ = "Square root of negative number";
+                    return false;
+                }
+                stack_.back() = dual_sqrt(stack_.back());
+                break;
+            }
+
+            case OpCode::ABS: {
+                if (stack_.empty()) {
+                    error_message_ = "Stack underflow in ABS";
+                    return false;
+                }
+                stack_.back() = dual_abs(stack_.back());
+                break;
+            }
+
+            case OpCode::RETURN: {
+                if (stack_.size() != 1) {
+                    error_message_ = "Invalid stack size at return";
+                    return false;
+                }
+                result = stack_.back();
+                return true;
+            }
+        }
+    }
+
+    error_message_ = "Missing return instruction";
+    return false;
+}
+
+bool AutoDiff::compute_gradient(const BytecodeProgram& program,
+                                 const double* inputs,
+                                 size_t num_inputs,
+                                 double* gradient) {
+    error_message_.clear();
+
+    if (num_inputs != program.num_variables()) {
+        error_message_ = "Input count mismatch";
+        return false;
+    }
+
+    std::vector<Dual> dual_inputs(num_inputs);
+
+    // Compute partial derivative for each variable
+    for (size_t i = 0; i < num_inputs; ++i) {
+        // Set up dual numbers: seed the derivative for variable i
+        for (size_t j = 0; j < num_inputs; ++j) {
+            dual_inputs[j] = Dual(inputs[j], (i == j) ? 1.0 : 0.0);
+        }
+
+        Dual result;
+        if (!execute_dual(program, dual_inputs.data(), num_inputs, result)) {
+            return false;
+        }
+
+        gradient[i] = result.derivative;
+    }
+
+    return true;
+}
+
+bool AutoDiff::compute_hessian(const BytecodeProgram& program,
+                                const double* inputs,
+                                size_t num_inputs,
+                                double* hessian) {
+    error_message_.clear();
+
+    if (num_inputs != program.num_variables()) {
+        error_message_ = "Input count mismatch";
+        return false;
+    }
+
+    // Nested forward-mode: For each pair (i,j), compute d²f/dx_i dx_j
+    // This is simplified - a full implementation would use dual-of-dual numbers
+    // For now, use finite differences on the gradient
+
+    std::vector<double> grad_base(num_inputs);
+    std::vector<double> grad_perturbed(num_inputs);
+    std::vector<double> inputs_perturbed(inputs, inputs + num_inputs);
+    const double h = 1e-8;
+
+    // Compute base gradient
+    if (!compute_gradient(program, inputs, num_inputs, grad_base.data())) {
+        return false;
+    }
+
+    // Compute Hessian using finite differences on gradient
+    for (size_t i = 0; i < num_inputs; ++i) {
+        inputs_perturbed[i] = inputs[i] + h;
+
+        if (!compute_gradient(program, inputs_perturbed.data(), num_inputs,
+                             grad_perturbed.data())) {
+            return false;
+        }
+
+        for (size_t j = 0; j < num_inputs; ++j) {
+            hessian[i * num_inputs + j] = (grad_perturbed[j] - grad_base[j]) / h;
+        }
+
+        inputs_perturbed[i] = inputs[i];
+    }
+
+    return true;
+}
+
+} // namespace ndcalc

--- a/ndcalc-core/src/bytecode.cpp
+++ b/ndcalc-core/src/bytecode.cpp
@@ -1,0 +1,73 @@
+#include "ndcalc/bytecode.h"
+#include <sstream>
+
+namespace ndcalc {
+
+void BytecodeProgram::add_instruction(const Instruction& inst) {
+    instructions_.push_back(inst);
+}
+
+std::string BytecodeProgram::disassemble() const {
+    std::ostringstream oss;
+    oss << "Bytecode (variables: " << num_variables_ << "):\n";
+
+    for (size_t i = 0; i < instructions_.size(); ++i) {
+        oss << "  " << i << ": ";
+
+        switch (instructions_[i].opcode) {
+            case OpCode::PUSH_CONST:
+                oss << "PUSH_CONST " << instructions_[i].operand.const_value;
+                break;
+            case OpCode::LOAD_VAR:
+                oss << "LOAD_VAR " << instructions_[i].operand.var_index;
+                break;
+            case OpCode::ADD:
+                oss << "ADD";
+                break;
+            case OpCode::SUB:
+                oss << "SUB";
+                break;
+            case OpCode::MUL:
+                oss << "MUL";
+                break;
+            case OpCode::DIV:
+                oss << "DIV";
+                break;
+            case OpCode::NEG:
+                oss << "NEG";
+                break;
+            case OpCode::POW:
+                oss << "POW";
+                break;
+            case OpCode::SIN:
+                oss << "SIN";
+                break;
+            case OpCode::COS:
+                oss << "COS";
+                break;
+            case OpCode::TAN:
+                oss << "TAN";
+                break;
+            case OpCode::EXP:
+                oss << "EXP";
+                break;
+            case OpCode::LOG:
+                oss << "LOG";
+                break;
+            case OpCode::SQRT:
+                oss << "SQRT";
+                break;
+            case OpCode::ABS:
+                oss << "ABS";
+                break;
+            case OpCode::RETURN:
+                oss << "RETURN";
+                break;
+        }
+        oss << "\n";
+    }
+
+    return oss.str();
+}
+
+} // namespace ndcalc

--- a/ndcalc-core/src/compiler.cpp
+++ b/ndcalc-core/src/compiler.cpp
@@ -1,0 +1,137 @@
+#include "ndcalc/compiler.h"
+#include <sstream>
+
+namespace ndcalc {
+
+Compiler::Compiler() {}
+
+std::unique_ptr<BytecodeProgram> Compiler::compile(const ASTNode& ast) {
+    error_message_.clear();
+
+    auto program = std::make_unique<BytecodeProgram>();
+
+    try {
+        compile_node(ast, *program);
+        program->add_instruction(Instruction(OpCode::RETURN));
+    } catch (const std::exception& e) {
+        error_message_ = e.what();
+        return nullptr;
+    }
+
+    return program;
+}
+
+void Compiler::compile_node(const ASTNode& node, BytecodeProgram& program) {
+    switch (node.type) {
+        case ASTNodeType::NUMBER: {
+            double value = std::stod(node.value);
+            program.add_instruction(Instruction(OpCode::PUSH_CONST, value));
+            break;
+        }
+
+        case ASTNodeType::VARIABLE: {
+            size_t index = std::stoull(node.value);
+            program.add_instruction(Instruction(OpCode::LOAD_VAR, index));
+            break;
+        }
+
+        case ASTNodeType::BINARY_OP: {
+            if (node.children.size() != 2) {
+                throw std::runtime_error("Binary operation requires exactly 2 operands");
+            }
+
+            // Compile operands
+            compile_node(*node.children[0], program);
+            compile_node(*node.children[1], program);
+
+            // Emit operator instruction
+            if (node.value == "+") {
+                program.add_instruction(Instruction(OpCode::ADD));
+            } else if (node.value == "-") {
+                program.add_instruction(Instruction(OpCode::SUB));
+            } else if (node.value == "*") {
+                program.add_instruction(Instruction(OpCode::MUL));
+            } else if (node.value == "/") {
+                program.add_instruction(Instruction(OpCode::DIV));
+            } else if (node.value == "^") {
+                program.add_instruction(Instruction(OpCode::POW));
+            } else {
+                throw std::runtime_error("Unknown binary operator: " + node.value);
+            }
+            break;
+        }
+
+        case ASTNodeType::UNARY_OP: {
+            if (node.children.size() != 1) {
+                throw std::runtime_error("Unary operation requires exactly 1 operand");
+            }
+
+            compile_node(*node.children[0], program);
+
+            if (node.value == "-") {
+                program.add_instruction(Instruction(OpCode::NEG));
+            } else {
+                throw std::runtime_error("Unknown unary operator: " + node.value);
+            }
+            break;
+        }
+
+        case ASTNodeType::FUNCTION_CALL: {
+            if (node.value == "sin") {
+                if (node.children.size() != 1) {
+                    throw std::runtime_error("sin() requires exactly 1 argument");
+                }
+                compile_node(*node.children[0], program);
+                program.add_instruction(Instruction(OpCode::SIN));
+            } else if (node.value == "cos") {
+                if (node.children.size() != 1) {
+                    throw std::runtime_error("cos() requires exactly 1 argument");
+                }
+                compile_node(*node.children[0], program);
+                program.add_instruction(Instruction(OpCode::COS));
+            } else if (node.value == "tan") {
+                if (node.children.size() != 1) {
+                    throw std::runtime_error("tan() requires exactly 1 argument");
+                }
+                compile_node(*node.children[0], program);
+                program.add_instruction(Instruction(OpCode::TAN));
+            } else if (node.value == "exp") {
+                if (node.children.size() != 1) {
+                    throw std::runtime_error("exp() requires exactly 1 argument");
+                }
+                compile_node(*node.children[0], program);
+                program.add_instruction(Instruction(OpCode::EXP));
+            } else if (node.value == "log") {
+                if (node.children.size() != 1) {
+                    throw std::runtime_error("log() requires exactly 1 argument");
+                }
+                compile_node(*node.children[0], program);
+                program.add_instruction(Instruction(OpCode::LOG));
+            } else if (node.value == "sqrt") {
+                if (node.children.size() != 1) {
+                    throw std::runtime_error("sqrt() requires exactly 1 argument");
+                }
+                compile_node(*node.children[0], program);
+                program.add_instruction(Instruction(OpCode::SQRT));
+            } else if (node.value == "abs") {
+                if (node.children.size() != 1) {
+                    throw std::runtime_error("abs() requires exactly 1 argument");
+                }
+                compile_node(*node.children[0], program);
+                program.add_instruction(Instruction(OpCode::ABS));
+            } else if (node.value == "pow") {
+                if (node.children.size() != 2) {
+                    throw std::runtime_error("pow() requires exactly 2 arguments");
+                }
+                compile_node(*node.children[0], program);
+                compile_node(*node.children[1], program);
+                program.add_instruction(Instruction(OpCode::POW));
+            } else {
+                throw std::runtime_error("Unknown function: " + node.value);
+            }
+            break;
+        }
+    }
+}
+
+} // namespace ndcalc

--- a/ndcalc-core/src/finite_diff.cpp
+++ b/ndcalc-core/src/finite_diff.cpp
@@ -1,0 +1,123 @@
+#include "ndcalc/finite_diff.h"
+#include <vector>
+#include <cmath>
+
+namespace ndcalc {
+
+FiniteDiff::FiniteDiff(double epsilon) : epsilon_(epsilon) {}
+
+bool FiniteDiff::compute_gradient(const BytecodeProgram& program,
+                                   VM& vm,
+                                   const double* inputs,
+                                   size_t num_inputs,
+                                   double* gradient) {
+    error_message_.clear();
+
+    if (num_inputs != program.num_variables()) {
+        error_message_ = "Input count mismatch";
+        return false;
+    }
+
+    std::vector<double> inputs_plus(inputs, inputs + num_inputs);
+    std::vector<double> inputs_minus(inputs, inputs + num_inputs);
+
+    double f_plus, f_minus;
+
+    // Central difference for each variable
+    for (size_t i = 0; i < num_inputs; ++i) {
+        // f(x + h*e_i)
+        inputs_plus[i] = inputs[i] + epsilon_;
+        if (!vm.execute(program, inputs_plus.data(), num_inputs, f_plus)) {
+            error_message_ = "Failed to evaluate at perturbed point (+): " + vm.get_error();
+            return false;
+        }
+
+        // f(x - h*e_i)
+        inputs_minus[i] = inputs[i] - epsilon_;
+        if (!vm.execute(program, inputs_minus.data(), num_inputs, f_minus)) {
+            error_message_ = "Failed to evaluate at perturbed point (-): " + vm.get_error();
+            return false;
+        }
+
+        // Central difference: (f(x+h) - f(x-h)) / (2h)
+        gradient[i] = (f_plus - f_minus) / (2.0 * epsilon_);
+
+        // Restore inputs
+        inputs_plus[i] = inputs[i];
+        inputs_minus[i] = inputs[i];
+    }
+
+    return true;
+}
+
+bool FiniteDiff::compute_hessian(const BytecodeProgram& program,
+                                  VM& vm,
+                                  const double* inputs,
+                                  size_t num_inputs,
+                                  double* hessian) {
+    error_message_.clear();
+
+    if (num_inputs != program.num_variables()) {
+        error_message_ = "Input count mismatch";
+        return false;
+    }
+
+    std::vector<double> inputs_perturbed(inputs, inputs + num_inputs);
+    double f_base, f_i_plus, f_i_minus, f_j_plus, f_j_minus, f_ij;
+
+    // Compute base value
+    if (!vm.execute(program, inputs, num_inputs, f_base)) {
+        error_message_ = "Failed to evaluate at base point: " + vm.get_error();
+        return false;
+    }
+
+    // Compute Hessian using finite differences
+    for (size_t i = 0; i < num_inputs; ++i) {
+        // Diagonal elements: H_ii = (f(x+h*e_i) - 2*f(x) + f(x-h*e_i)) / h²
+        inputs_perturbed[i] = inputs[i] + epsilon_;
+        if (!vm.execute(program, inputs_perturbed.data(), num_inputs, f_i_plus)) {
+            error_message_ = "Failed to evaluate at perturbed point: " + vm.get_error();
+            return false;
+        }
+
+        inputs_perturbed[i] = inputs[i] - epsilon_;
+        if (!vm.execute(program, inputs_perturbed.data(), num_inputs, f_i_minus)) {
+            error_message_ = "Failed to evaluate at perturbed point: " + vm.get_error();
+            return false;
+        }
+
+        hessian[i * num_inputs + i] = (f_i_plus - 2.0 * f_base + f_i_minus) / (epsilon_ * epsilon_);
+
+        inputs_perturbed[i] = inputs[i];
+
+        // Off-diagonal elements: H_ij = (f(x+h*e_i+h*e_j) - f(x+h*e_i) - f(x+h*e_j) + f(x)) / h²
+        for (size_t j = i + 1; j < num_inputs; ++j) {
+            // f(x + h*e_i + h*e_j)
+            inputs_perturbed[i] = inputs[i] + epsilon_;
+            inputs_perturbed[j] = inputs[j] + epsilon_;
+            if (!vm.execute(program, inputs_perturbed.data(), num_inputs, f_ij)) {
+                error_message_ = "Failed to evaluate at perturbed point: " + vm.get_error();
+                return false;
+            }
+
+            // f(x + h*e_j)
+            inputs_perturbed[i] = inputs[i];
+            inputs_perturbed[j] = inputs[j] + epsilon_;
+            if (!vm.execute(program, inputs_perturbed.data(), num_inputs, f_j_plus)) {
+                error_message_ = "Failed to evaluate at perturbed point: " + vm.get_error();
+                return false;
+            }
+
+            // Mixed partial
+            double h_ij = (f_ij - f_i_plus - f_j_plus + f_base) / (epsilon_ * epsilon_);
+            hessian[i * num_inputs + j] = h_ij;
+            hessian[j * num_inputs + i] = h_ij; // Symmetry
+
+            inputs_perturbed[j] = inputs[j];
+        }
+    }
+
+    return true;
+}
+
+} // namespace ndcalc

--- a/ndcalc-core/src/parser.cpp
+++ b/ndcalc-core/src/parser.cpp
@@ -1,0 +1,269 @@
+#include "ndcalc/parser.h"
+#include <cctype>
+#include <cmath>
+#include <sstream>
+
+namespace ndcalc {
+
+Parser::Parser() {}
+
+std::vector<Token> Parser::tokenize(const std::string& expression) {
+    std::vector<Token> tokens;
+    size_t pos = 0;
+
+    while (pos < expression.length()) {
+        // Skip whitespace
+        if (std::isspace(expression[pos])) {
+            ++pos;
+            continue;
+        }
+
+        // Numbers
+        if (std::isdigit(expression[pos]) || expression[pos] == '.') {
+            size_t start = pos;
+            while (pos < expression.length() &&
+                   (std::isdigit(expression[pos]) || expression[pos] == '.' ||
+                    expression[pos] == 'e' || expression[pos] == 'E' ||
+                    (pos > start && (expression[pos] == '+' || expression[pos] == '-')))) {
+                ++pos;
+            }
+            tokens.push_back({TokenType::NUMBER, expression.substr(start, pos - start), start});
+            continue;
+        }
+
+        // Variables and functions
+        if (std::isalpha(expression[pos]) || expression[pos] == '_') {
+            size_t start = pos;
+            while (pos < expression.length() &&
+                   (std::isalnum(expression[pos]) || expression[pos] == '_')) {
+                ++pos;
+            }
+            std::string name = expression.substr(start, pos - start);
+
+            // Check if it's a known function
+            if (name == "sin" || name == "cos" || name == "tan" ||
+                name == "exp" || name == "log" || name == "sqrt" || name == "abs" ||
+                name == "pow") {
+                tokens.push_back({TokenType::FUNCTION, name, start});
+            } else {
+                tokens.push_back({TokenType::VARIABLE, name, start});
+            }
+            continue;
+        }
+
+        // Operators and delimiters
+        switch (expression[pos]) {
+            case '+':
+            case '-':
+            case '*':
+            case '/':
+            case '^':
+                tokens.push_back({TokenType::OPERATOR, std::string(1, expression[pos]), pos});
+                ++pos;
+                break;
+            case '(':
+                tokens.push_back({TokenType::LPAREN, "(", pos});
+                ++pos;
+                break;
+            case ')':
+                tokens.push_back({TokenType::RPAREN, ")", pos});
+                ++pos;
+                break;
+            case ',':
+                tokens.push_back({TokenType::COMMA, ",", pos});
+                ++pos;
+                break;
+            default:
+                error_message_ = "Unexpected character at position " + std::to_string(pos);
+                return {};
+        }
+    }
+
+    tokens.push_back({TokenType::END, "", expression.length()});
+    return tokens;
+}
+
+std::unique_ptr<ASTNode> Parser::parse(const std::string& expression,
+                                        const std::vector<std::string>& variables) {
+    error_message_.clear();
+    variable_indices_.clear();
+
+    for (size_t i = 0; i < variables.size(); ++i) {
+        variable_indices_[variables[i]] = i;
+    }
+
+    tokens_ = tokenize(expression);
+    if (tokens_.empty()) {
+        return nullptr;
+    }
+
+    size_t pos = 0;
+    auto result = parse_expression(pos);
+
+    if (result && tokens_[pos].type != TokenType::END) {
+        error_message_ = "Unexpected tokens after expression";
+        return nullptr;
+    }
+
+    return result;
+}
+
+std::unique_ptr<ASTNode> Parser::parse_expression(size_t& pos) {
+    auto left = parse_term(pos);
+    if (!left) return nullptr;
+
+    while (pos < tokens_.size() && tokens_[pos].type == TokenType::OPERATOR &&
+           (tokens_[pos].value == "+" || tokens_[pos].value == "-")) {
+        std::string op = tokens_[pos].value;
+        ++pos;
+
+        auto right = parse_term(pos);
+        if (!right) return nullptr;
+
+        auto node = std::make_unique<ASTNode>(ASTNodeType::BINARY_OP, op);
+        node->children.push_back(std::move(left));
+        node->children.push_back(std::move(right));
+        left = std::move(node);
+    }
+
+    return left;
+}
+
+std::unique_ptr<ASTNode> Parser::parse_term(size_t& pos) {
+    auto left = parse_factor(pos);
+    if (!left) return nullptr;
+
+    while (pos < tokens_.size() && tokens_[pos].type == TokenType::OPERATOR &&
+           (tokens_[pos].value == "*" || tokens_[pos].value == "/")) {
+        std::string op = tokens_[pos].value;
+        ++pos;
+
+        auto right = parse_factor(pos);
+        if (!right) return nullptr;
+
+        auto node = std::make_unique<ASTNode>(ASTNodeType::BINARY_OP, op);
+        node->children.push_back(std::move(left));
+        node->children.push_back(std::move(right));
+        left = std::move(node);
+    }
+
+    return left;
+}
+
+std::unique_ptr<ASTNode> Parser::parse_factor(size_t& pos) {
+    auto left = parse_primary(pos);
+    if (!left) return nullptr;
+
+    while (pos < tokens_.size() && tokens_[pos].type == TokenType::OPERATOR &&
+           tokens_[pos].value == "^") {
+        ++pos;
+
+        auto right = parse_primary(pos);
+        if (!right) return nullptr;
+
+        auto node = std::make_unique<ASTNode>(ASTNodeType::BINARY_OP, "^");
+        node->children.push_back(std::move(left));
+        node->children.push_back(std::move(right));
+        left = std::move(node);
+    }
+
+    return left;
+}
+
+std::unique_ptr<ASTNode> Parser::parse_primary(size_t& pos) {
+    if (pos >= tokens_.size()) {
+        error_message_ = "Unexpected end of expression";
+        return nullptr;
+    }
+
+    // Unary minus
+    if (tokens_[pos].type == TokenType::OPERATOR && tokens_[pos].value == "-") {
+        ++pos;
+        auto operand = parse_primary(pos);
+        if (!operand) return nullptr;
+
+        auto node = std::make_unique<ASTNode>(ASTNodeType::UNARY_OP, "-");
+        node->children.push_back(std::move(operand));
+        return node;
+    }
+
+    // Unary plus
+    if (tokens_[pos].type == TokenType::OPERATOR && tokens_[pos].value == "+") {
+        ++pos;
+        return parse_primary(pos);
+    }
+
+    // Numbers
+    if (tokens_[pos].type == TokenType::NUMBER) {
+        auto node = std::make_unique<ASTNode>(ASTNodeType::NUMBER, tokens_[pos].value);
+        ++pos;
+        return node;
+    }
+
+    // Variables
+    if (tokens_[pos].type == TokenType::VARIABLE) {
+        std::string var_name = tokens_[pos].value;
+        if (variable_indices_.find(var_name) == variable_indices_.end()) {
+            error_message_ = "Unknown variable: " + var_name;
+            return nullptr;
+        }
+        auto node = std::make_unique<ASTNode>(ASTNodeType::VARIABLE,
+                                               std::to_string(variable_indices_[var_name]));
+        ++pos;
+        return node;
+    }
+
+    // Functions
+    if (tokens_[pos].type == TokenType::FUNCTION) {
+        std::string func_name = tokens_[pos].value;
+        ++pos;
+
+        if (pos >= tokens_.size() || tokens_[pos].type != TokenType::LPAREN) {
+            error_message_ = "Expected '(' after function name";
+            return nullptr;
+        }
+        ++pos;
+
+        auto node = std::make_unique<ASTNode>(ASTNodeType::FUNCTION_CALL, func_name);
+
+        // Parse arguments
+        if (tokens_[pos].type != TokenType::RPAREN) {
+            while (true) {
+                auto arg = parse_expression(pos);
+                if (!arg) return nullptr;
+                node->children.push_back(std::move(arg));
+
+                if (tokens_[pos].type == TokenType::RPAREN) {
+                    break;
+                } else if (tokens_[pos].type == TokenType::COMMA) {
+                    ++pos;
+                } else {
+                    error_message_ = "Expected ',' or ')' in function call";
+                    return nullptr;
+                }
+            }
+        }
+        ++pos; // consume ')'
+
+        return node;
+    }
+
+    // Parenthesized expression
+    if (tokens_[pos].type == TokenType::LPAREN) {
+        ++pos;
+        auto node = parse_expression(pos);
+        if (!node) return nullptr;
+
+        if (pos >= tokens_.size() || tokens_[pos].type != TokenType::RPAREN) {
+            error_message_ = "Expected closing parenthesis";
+            return nullptr;
+        }
+        ++pos;
+        return node;
+    }
+
+    error_message_ = "Unexpected token";
+    return nullptr;
+}
+
+} // namespace ndcalc

--- a/ndcalc-core/src/vm.cpp
+++ b/ndcalc-core/src/vm.cpp
@@ -1,0 +1,222 @@
+#include "ndcalc/vm.h"
+#include <cmath>
+#include <limits>
+
+namespace ndcalc {
+
+VM::VM() {
+    stack_.reserve(256);
+}
+
+bool VM::execute(const BytecodeProgram& program,
+                 const double* inputs,
+                 size_t num_inputs,
+                 double& result) {
+    clear_error();
+    stack_.clear();
+
+    if (num_inputs != program.num_variables()) {
+        set_error("Input count mismatch");
+        return false;
+    }
+
+    for (const auto& inst : program.instructions()) {
+        switch (inst.opcode) {
+            case OpCode::PUSH_CONST:
+                stack_.push_back(inst.operand.const_value);
+                break;
+
+            case OpCode::LOAD_VAR: {
+                size_t idx = inst.operand.var_index;
+                if (idx >= num_inputs) {
+                    set_error("Variable index out of bounds");
+                    return false;
+                }
+                stack_.push_back(inputs[idx]);
+                break;
+            }
+
+            case OpCode::ADD: {
+                if (stack_.size() < 2) {
+                    set_error("Stack underflow in ADD");
+                    return false;
+                }
+                double b = stack_.back(); stack_.pop_back();
+                double a = stack_.back(); stack_.pop_back();
+                stack_.push_back(a + b);
+                break;
+            }
+
+            case OpCode::SUB: {
+                if (stack_.size() < 2) {
+                    set_error("Stack underflow in SUB");
+                    return false;
+                }
+                double b = stack_.back(); stack_.pop_back();
+                double a = stack_.back(); stack_.pop_back();
+                stack_.push_back(a - b);
+                break;
+            }
+
+            case OpCode::MUL: {
+                if (stack_.size() < 2) {
+                    set_error("Stack underflow in MUL");
+                    return false;
+                }
+                double b = stack_.back(); stack_.pop_back();
+                double a = stack_.back(); stack_.pop_back();
+                stack_.push_back(a * b);
+                break;
+            }
+
+            case OpCode::DIV: {
+                if (stack_.size() < 2) {
+                    set_error("Stack underflow in DIV");
+                    return false;
+                }
+                double b = stack_.back(); stack_.pop_back();
+                double a = stack_.back(); stack_.pop_back();
+                if (b == 0.0) {
+                    set_error("Division by zero");
+                    return false;
+                }
+                stack_.push_back(a / b);
+                break;
+            }
+
+            case OpCode::NEG: {
+                if (stack_.empty()) {
+                    set_error("Stack underflow in NEG");
+                    return false;
+                }
+                stack_.back() = -stack_.back();
+                break;
+            }
+
+            case OpCode::POW: {
+                if (stack_.size() < 2) {
+                    set_error("Stack underflow in POW");
+                    return false;
+                }
+                double b = stack_.back(); stack_.pop_back();
+                double a = stack_.back(); stack_.pop_back();
+                stack_.push_back(std::pow(a, b));
+                break;
+            }
+
+            case OpCode::SIN: {
+                if (stack_.empty()) {
+                    set_error("Stack underflow in SIN");
+                    return false;
+                }
+                stack_.back() = std::sin(stack_.back());
+                break;
+            }
+
+            case OpCode::COS: {
+                if (stack_.empty()) {
+                    set_error("Stack underflow in COS");
+                    return false;
+                }
+                stack_.back() = std::cos(stack_.back());
+                break;
+            }
+
+            case OpCode::TAN: {
+                if (stack_.empty()) {
+                    set_error("Stack underflow in TAN");
+                    return false;
+                }
+                stack_.back() = std::tan(stack_.back());
+                break;
+            }
+
+            case OpCode::EXP: {
+                if (stack_.empty()) {
+                    set_error("Stack underflow in EXP");
+                    return false;
+                }
+                stack_.back() = std::exp(stack_.back());
+                break;
+            }
+
+            case OpCode::LOG: {
+                if (stack_.empty()) {
+                    set_error("Stack underflow in LOG");
+                    return false;
+                }
+                if (stack_.back() <= 0.0) {
+                    set_error("Logarithm of non-positive number");
+                    return false;
+                }
+                stack_.back() = std::log(stack_.back());
+                break;
+            }
+
+            case OpCode::SQRT: {
+                if (stack_.empty()) {
+                    set_error("Stack underflow in SQRT");
+                    return false;
+                }
+                if (stack_.back() < 0.0) {
+                    set_error("Square root of negative number");
+                    return false;
+                }
+                stack_.back() = std::sqrt(stack_.back());
+                break;
+            }
+
+            case OpCode::ABS: {
+                if (stack_.empty()) {
+                    set_error("Stack underflow in ABS");
+                    return false;
+                }
+                stack_.back() = std::abs(stack_.back());
+                break;
+            }
+
+            case OpCode::RETURN: {
+                if (stack_.size() != 1) {
+                    set_error("Invalid stack size at return");
+                    return false;
+                }
+                result = stack_.back();
+                return true;
+            }
+        }
+    }
+
+    set_error("Missing return instruction");
+    return false;
+}
+
+bool VM::execute_batch(const BytecodeProgram& program,
+                       const double* const* input_arrays,
+                       size_t num_variables,
+                       size_t num_points,
+                       double* output_array) {
+    clear_error();
+
+    if (num_variables != program.num_variables()) {
+        set_error("Input count mismatch");
+        return false;
+    }
+
+    std::vector<double> point_inputs(num_variables);
+
+    for (size_t i = 0; i < num_points; ++i) {
+        // Gather inputs for this point
+        for (size_t v = 0; v < num_variables; ++v) {
+            point_inputs[v] = input_arrays[v][i];
+        }
+
+        // Execute for this point
+        if (!execute(program, point_inputs.data(), num_variables, output_array[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+} // namespace ndcalc

--- a/ndcalc-core/tests/CMakeLists.txt
+++ b/ndcalc-core/tests/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.20)
+
+# Simple test runner without external dependencies
+add_executable(ndcalc_tests
+    test_parser.cpp
+    test_vm.cpp
+    test_autodiff.cpp
+    test_api.cpp
+)
+
+target_link_libraries(ndcalc_tests PRIVATE ndcalc)
+
+# Add test
+add_test(NAME ndcalc_tests COMMAND ndcalc_tests)

--- a/ndcalc-core/tests/test_api.cpp
+++ b/ndcalc-core/tests/test_api.cpp
@@ -1,0 +1,161 @@
+#include "ndcalc/api.h"
+#include <iostream>
+#include <cassert>
+#include <cmath>
+
+bool approx_equal(double a, double b, double epsilon = 1e-6) {
+    return std::abs(a - b) < epsilon;
+}
+
+void test_compile_and_eval() {
+    ndcalc_context_handle ctx = ndcalc_context_create();
+    assert(ctx != nullptr);
+
+    const char* vars[] = {"x", "y"};
+    ndcalc_program_handle program;
+
+    ndcalc_error_t err = ndcalc_compile(ctx, "x + y", 2, vars, &program);
+    assert(err == NDCALC_OK);
+    assert(program != nullptr);
+
+    double inputs[] = {3.0, 4.0};
+    double output;
+    err = ndcalc_eval(program, inputs, 2, &output);
+    assert(err == NDCALC_OK);
+    assert(approx_equal(output, 7.0));
+
+    ndcalc_program_destroy(program);
+    ndcalc_context_destroy(ctx);
+
+    std::cout << "✓ test_compile_and_eval passed\n";
+}
+
+void test_gradient() {
+    ndcalc_context_handle ctx = ndcalc_context_create();
+
+    const char* vars[] = {"x", "y"};
+    ndcalc_program_handle program;
+
+    ndcalc_error_t err = ndcalc_compile(ctx, "x^2 + y^2", 2, vars, &program);
+    assert(err == NDCALC_OK);
+
+    double inputs[] = {3.0, 4.0};
+    double gradient[2];
+    err = ndcalc_gradient(program, inputs, 2, gradient);
+    assert(err == NDCALC_OK);
+
+    assert(approx_equal(gradient[0], 6.0));
+    assert(approx_equal(gradient[1], 8.0));
+
+    ndcalc_program_destroy(program);
+    ndcalc_context_destroy(ctx);
+
+    std::cout << "✓ test_gradient passed\n";
+}
+
+void test_hessian() {
+    ndcalc_context_handle ctx = ndcalc_context_create();
+
+    const char* vars[] = {"x", "y"};
+    ndcalc_program_handle program;
+
+    ndcalc_error_t err = ndcalc_compile(ctx, "x^2 + y^2", 2, vars, &program);
+    assert(err == NDCALC_OK);
+
+    double inputs[] = {3.0, 4.0};
+    double hessian[4];
+    err = ndcalc_hessian(program, inputs, 2, hessian);
+    assert(err == NDCALC_OK);
+
+    assert(approx_equal(hessian[0], 2.0, 1e-4));
+    assert(approx_equal(hessian[3], 2.0, 1e-4));
+    assert(approx_equal(hessian[1], 0.0, 1e-4));
+    assert(approx_equal(hessian[2], 0.0, 1e-4));
+
+    ndcalc_program_destroy(program);
+    ndcalc_context_destroy(ctx);
+
+    std::cout << "✓ test_hessian passed\n";
+}
+
+void test_batch_eval() {
+    ndcalc_context_handle ctx = ndcalc_context_create();
+
+    const char* vars[] = {"x", "y"};
+    ndcalc_program_handle program;
+
+    ndcalc_error_t err = ndcalc_compile(ctx, "x + y", 2, vars, &program);
+    assert(err == NDCALC_OK);
+
+    double x_array[] = {1.0, 2.0, 3.0};
+    double y_array[] = {4.0, 5.0, 6.0};
+    const double* inputs[] = {x_array, y_array};
+    double outputs[3];
+
+    err = ndcalc_eval_batch(program, inputs, 2, 3, outputs);
+    assert(err == NDCALC_OK);
+
+    assert(approx_equal(outputs[0], 5.0));
+    assert(approx_equal(outputs[1], 7.0));
+    assert(approx_equal(outputs[2], 9.0));
+
+    ndcalc_program_destroy(program);
+    ndcalc_context_destroy(ctx);
+
+    std::cout << "✓ test_batch_eval passed\n";
+}
+
+void test_error_handling() {
+    ndcalc_context_handle ctx = ndcalc_context_create();
+
+    const char* vars[] = {"x"};
+    ndcalc_program_handle program;
+
+    // Invalid expression
+    ndcalc_error_t err = ndcalc_compile(ctx, "x +", 1, vars, &program);
+    assert(err != NDCALC_OK);
+
+    const char* error_msg = ndcalc_get_last_error_message(ctx);
+    assert(error_msg != nullptr);
+
+    ndcalc_context_destroy(ctx);
+
+    std::cout << "✓ test_error_handling passed\n";
+}
+
+void test_trig_functions() {
+    ndcalc_context_handle ctx = ndcalc_context_create();
+
+    const char* vars[] = {"x"};
+    ndcalc_program_handle program;
+
+    ndcalc_error_t err = ndcalc_compile(ctx, "sin(x) + cos(x)", 1, vars, &program);
+    assert(err == NDCALC_OK);
+
+    double inputs[] = {M_PI / 4.0};
+    double output;
+    err = ndcalc_eval(program, inputs, 1, &output);
+    assert(err == NDCALC_OK);
+
+    double expected = std::sin(M_PI / 4.0) + std::cos(M_PI / 4.0);
+    assert(approx_equal(output, expected));
+
+    ndcalc_program_destroy(program);
+    ndcalc_context_destroy(ctx);
+
+    std::cout << "✓ test_trig_functions passed\n";
+}
+
+int main() {
+    std::cout << "Running API tests...\n";
+
+    test_compile_and_eval();
+    test_gradient();
+    test_hessian();
+    test_batch_eval();
+    test_error_handling();
+    test_trig_functions();
+
+    std::cout << "All API tests passed!\n";
+    return 0;
+}

--- a/ndcalc-core/tests/test_autodiff.cpp
+++ b/ndcalc-core/tests/test_autodiff.cpp
@@ -1,0 +1,161 @@
+#include "ndcalc/parser.h"
+#include "ndcalc/compiler.h"
+#include "ndcalc/autodiff.h"
+#include <iostream>
+#include <cassert>
+#include <cmath>
+
+using namespace ndcalc;
+
+bool approx_equal(double a, double b, double epsilon = 1e-6) {
+    return std::abs(a - b) < epsilon;
+}
+
+void test_gradient_linear() {
+    Parser parser;
+    Compiler compiler;
+    AutoDiff autodiff;
+
+    // f(x, y) = x + y
+    // ∂f/∂x = 1, ∂f/∂y = 1
+    std::vector<std::string> vars = {"x", "y"};
+    auto ast = parser.parse("x + y", vars);
+    auto program = compiler.compile(*ast);
+    program->set_num_variables(2);
+
+    double inputs[] = {3.0, 4.0};
+    double gradient[2];
+    assert(autodiff.compute_gradient(*program, inputs, 2, gradient));
+
+    assert(approx_equal(gradient[0], 1.0));
+    assert(approx_equal(gradient[1], 1.0));
+
+    std::cout << "✓ test_gradient_linear passed\n";
+}
+
+void test_gradient_quadratic() {
+    Parser parser;
+    Compiler compiler;
+    AutoDiff autodiff;
+
+    // f(x, y) = x^2 + y^2
+    // ∂f/∂x = 2x, ∂f/∂y = 2y
+    std::vector<std::string> vars = {"x", "y"};
+    auto ast = parser.parse("x^2 + y^2", vars);
+    auto program = compiler.compile(*ast);
+    program->set_num_variables(2);
+
+    double inputs[] = {3.0, 4.0};
+    double gradient[2];
+    assert(autodiff.compute_gradient(*program, inputs, 2, gradient));
+
+    assert(approx_equal(gradient[0], 6.0));  // 2 * 3
+    assert(approx_equal(gradient[1], 8.0));  // 2 * 4
+
+    std::cout << "✓ test_gradient_quadratic passed\n";
+}
+
+void test_gradient_product() {
+    Parser parser;
+    Compiler compiler;
+    AutoDiff autodiff;
+
+    // f(x, y) = x * y
+    // ∂f/∂x = y, ∂f/∂y = x
+    std::vector<std::string> vars = {"x", "y"};
+    auto ast = parser.parse("x * y", vars);
+    auto program = compiler.compile(*ast);
+    program->set_num_variables(2);
+
+    double inputs[] = {3.0, 4.0};
+    double gradient[2];
+    assert(autodiff.compute_gradient(*program, inputs, 2, gradient));
+
+    assert(approx_equal(gradient[0], 4.0));  // y
+    assert(approx_equal(gradient[1], 3.0));  // x
+
+    std::cout << "✓ test_gradient_product passed\n";
+}
+
+void test_gradient_sin() {
+    Parser parser;
+    Compiler compiler;
+    AutoDiff autodiff;
+
+    // f(x) = sin(x)
+    // ∂f/∂x = cos(x)
+    std::vector<std::string> vars = {"x"};
+    auto ast = parser.parse("sin(x)", vars);
+    auto program = compiler.compile(*ast);
+    program->set_num_variables(1);
+
+    double inputs[] = {M_PI / 4.0};
+    double gradient[1];
+    assert(autodiff.compute_gradient(*program, inputs, 1, gradient));
+
+    assert(approx_equal(gradient[0], std::cos(M_PI / 4.0)));
+
+    std::cout << "✓ test_gradient_sin passed\n";
+}
+
+void test_gradient_exp() {
+    Parser parser;
+    Compiler compiler;
+    AutoDiff autodiff;
+
+    // f(x) = exp(x)
+    // ∂f/∂x = exp(x)
+    std::vector<std::string> vars = {"x"};
+    auto ast = parser.parse("exp(x)", vars);
+    auto program = compiler.compile(*ast);
+    program->set_num_variables(1);
+
+    double inputs[] = {2.0};
+    double gradient[1];
+    assert(autodiff.compute_gradient(*program, inputs, 1, gradient));
+
+    assert(approx_equal(gradient[0], std::exp(2.0)));
+
+    std::cout << "✓ test_gradient_exp passed\n";
+}
+
+void test_hessian_simple() {
+    Parser parser;
+    Compiler compiler;
+    AutoDiff autodiff;
+
+    // f(x, y) = x^2 + y^2
+    // H = [[2, 0], [0, 2]]
+    std::vector<std::string> vars = {"x", "y"};
+    auto ast = parser.parse("x^2 + y^2", vars);
+    auto program = compiler.compile(*ast);
+    program->set_num_variables(2);
+
+    double inputs[] = {3.0, 4.0};
+    double hessian[4];
+    assert(autodiff.compute_hessian(*program, inputs, 2, hessian));
+
+    // Check diagonal elements (should be approximately 2)
+    assert(approx_equal(hessian[0], 2.0, 1e-4));
+    assert(approx_equal(hessian[3], 2.0, 1e-4));
+
+    // Check off-diagonal elements (should be approximately 0)
+    assert(approx_equal(hessian[1], 0.0, 1e-4));
+    assert(approx_equal(hessian[2], 0.0, 1e-4));
+
+    std::cout << "✓ test_hessian_simple passed\n";
+}
+
+int main() {
+    std::cout << "Running autodiff tests...\n";
+
+    test_gradient_linear();
+    test_gradient_quadratic();
+    test_gradient_product();
+    test_gradient_sin();
+    test_gradient_exp();
+    test_hessian_simple();
+
+    std::cout << "All autodiff tests passed!\n";
+    return 0;
+}

--- a/ndcalc-core/tests/test_parser.cpp
+++ b/ndcalc-core/tests/test_parser.cpp
@@ -1,0 +1,88 @@
+#include "ndcalc/parser.h"
+#include "ndcalc/compiler.h"
+#include <iostream>
+#include <cassert>
+#include <cmath>
+
+using namespace ndcalc;
+
+void test_simple_expression() {
+    Parser parser;
+    std::vector<std::string> vars = {"x", "y"};
+
+    auto ast = parser.parse("x + y", vars);
+    assert(ast != nullptr);
+    assert(ast->type == ASTNodeType::BINARY_OP);
+    assert(ast->value == "+");
+
+    std::cout << "✓ test_simple_expression passed\n";
+}
+
+void test_complex_expression() {
+    Parser parser;
+    std::vector<std::string> vars = {"x", "y", "z"};
+
+    auto ast = parser.parse("x * y + sin(z)", vars);
+    assert(ast != nullptr);
+
+    std::cout << "✓ test_complex_expression passed\n";
+}
+
+void test_function_call() {
+    Parser parser;
+    std::vector<std::string> vars = {"x"};
+
+    auto ast = parser.parse("sin(x) + cos(x)", vars);
+    assert(ast != nullptr);
+
+    std::cout << "✓ test_function_call passed\n";
+}
+
+void test_nested_functions() {
+    Parser parser;
+    std::vector<std::string> vars = {"x"};
+
+    auto ast = parser.parse("exp(sin(x * 2))", vars);
+    assert(ast != nullptr);
+
+    std::cout << "✓ test_nested_functions passed\n";
+}
+
+void test_power_operator() {
+    Parser parser;
+    std::vector<std::string> vars = {"x"};
+
+    auto ast = parser.parse("x^2 + x^3", vars);
+    assert(ast != nullptr);
+
+    std::cout << "✓ test_power_operator passed\n";
+}
+
+void test_compile() {
+    Parser parser;
+    Compiler compiler;
+    std::vector<std::string> vars = {"x", "y"};
+
+    auto ast = parser.parse("x + y * 2", vars);
+    assert(ast != nullptr);
+
+    auto program = compiler.compile(*ast);
+    assert(program != nullptr);
+    program->set_num_variables(2);
+
+    std::cout << "✓ test_compile passed\n";
+}
+
+int main() {
+    std::cout << "Running parser tests...\n";
+
+    test_simple_expression();
+    test_complex_expression();
+    test_function_call();
+    test_nested_functions();
+    test_power_operator();
+    test_compile();
+
+    std::cout << "All parser tests passed!\n";
+    return 0;
+}

--- a/ndcalc-core/tests/test_vm.cpp
+++ b/ndcalc-core/tests/test_vm.cpp
@@ -1,0 +1,143 @@
+#include "ndcalc/parser.h"
+#include "ndcalc/compiler.h"
+#include "ndcalc/vm.h"
+#include <iostream>
+#include <cassert>
+#include <cmath>
+
+using namespace ndcalc;
+
+bool approx_equal(double a, double b, double epsilon = 1e-10) {
+    return std::abs(a - b) < epsilon;
+}
+
+void test_basic_arithmetic() {
+    Parser parser;
+    Compiler compiler;
+    VM vm;
+
+    std::vector<std::string> vars = {"x", "y"};
+    auto ast = parser.parse("x + y", vars);
+    assert(ast != nullptr);
+
+    auto program = compiler.compile(*ast);
+    assert(program != nullptr);
+    program->set_num_variables(2);
+
+    double inputs[] = {3.0, 4.0};
+    double result;
+    assert(vm.execute(*program, inputs, 2, result));
+    assert(approx_equal(result, 7.0));
+
+    std::cout << "✓ test_basic_arithmetic passed\n";
+}
+
+void test_multiplication() {
+    Parser parser;
+    Compiler compiler;
+    VM vm;
+
+    std::vector<std::string> vars = {"x", "y"};
+    auto ast = parser.parse("x * y", vars);
+    auto program = compiler.compile(*ast);
+    program->set_num_variables(2);
+
+    double inputs[] = {3.0, 4.0};
+    double result;
+    assert(vm.execute(*program, inputs, 2, result));
+    assert(approx_equal(result, 12.0));
+
+    std::cout << "✓ test_multiplication passed\n";
+}
+
+void test_power() {
+    Parser parser;
+    Compiler compiler;
+    VM vm;
+
+    std::vector<std::string> vars = {"x"};
+    auto ast = parser.parse("x^2", vars);
+    auto program = compiler.compile(*ast);
+    program->set_num_variables(1);
+
+    double inputs[] = {5.0};
+    double result;
+    assert(vm.execute(*program, inputs, 1, result));
+    assert(approx_equal(result, 25.0));
+
+    std::cout << "✓ test_power passed\n";
+}
+
+void test_sin() {
+    Parser parser;
+    Compiler compiler;
+    VM vm;
+
+    std::vector<std::string> vars = {"x"};
+    auto ast = parser.parse("sin(x)", vars);
+    auto program = compiler.compile(*ast);
+    program->set_num_variables(1);
+
+    double inputs[] = {M_PI / 2.0};
+    double result;
+    assert(vm.execute(*program, inputs, 1, result));
+    assert(approx_equal(result, 1.0));
+
+    std::cout << "✓ test_sin passed\n";
+}
+
+void test_complex_expression() {
+    Parser parser;
+    Compiler compiler;
+    VM vm;
+
+    std::vector<std::string> vars = {"x", "y"};
+    auto ast = parser.parse("x^2 + y^2", vars);
+    auto program = compiler.compile(*ast);
+    program->set_num_variables(2);
+
+    double inputs[] = {3.0, 4.0};
+    double result;
+    assert(vm.execute(*program, inputs, 2, result));
+    assert(approx_equal(result, 25.0));
+
+    std::cout << "✓ test_complex_expression passed\n";
+}
+
+void test_batch_execution() {
+    Parser parser;
+    Compiler compiler;
+    VM vm;
+
+    std::vector<std::string> vars = {"x", "y"};
+    auto ast = parser.parse("x + y", vars);
+    auto program = compiler.compile(*ast);
+    program->set_num_variables(2);
+
+    // SoA layout
+    double x_array[] = {1.0, 2.0, 3.0};
+    double y_array[] = {4.0, 5.0, 6.0};
+    const double* inputs[] = {x_array, y_array};
+    double outputs[3];
+
+    assert(vm.execute_batch(*program, inputs, 2, 3, outputs));
+    assert(approx_equal(outputs[0], 5.0));
+    assert(approx_equal(outputs[1], 7.0));
+    assert(approx_equal(outputs[2], 9.0));
+
+    std::cout << "✓ test_batch_execution passed\n";
+}
+
+int main() {
+    std::cout << "Running VM tests...\n";
+
+    test_basic_arithmetic();
+    test_multiplication();
+    test_power();
+    test_sin();
+    test_complex_expression();
+    test_batch_execution();
+
+    std::cout << "All VM tests passed!\n";
+    return 0;
+}

--- a/ndcalc-core/wasm/CMakeLists.txt
+++ b/ndcalc-core/wasm/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.20)
+
+# WASM-specific compilation flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -fno-rtti")
+
+# WASM bindings
+add_executable(ndcalc_wasm
+    wasm_bindings.cpp
+    ../src/parser.cpp
+    ../src/bytecode.cpp
+    ../src/compiler.cpp
+    ../src/vm.cpp
+    ../src/autodiff.cpp
+    ../src/finite_diff.cpp
+    ../src/api.cpp
+)
+
+target_include_directories(ndcalc_wasm PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include
+)
+
+# Emscripten-specific link flags
+set_target_properties(ndcalc_wasm PROPERTIES
+    SUFFIX ".js"
+    LINK_FLAGS "\
+        -s WASM=1 \
+        -s EXPORTED_FUNCTIONS='[\"_malloc\",\"_free\"]' \
+        -s EXPORTED_RUNTIME_METHODS='[\"ccall\",\"cwrap\",\"getValue\",\"setValue\"]' \
+        -s ALLOW_MEMORY_GROWTH=1 \
+        -s MODULARIZE=1 \
+        -s EXPORT_ES6=1 \
+        -s EXPORT_NAME='createNdcalcModule' \
+        -s ENVIRONMENT='web,worker' \
+        --no-entry \
+        -O3"
+)

--- a/ndcalc-core/wasm/build.sh
+++ b/ndcalc-core/wasm/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+# Build WASM module using Emscripten
+echo "Building ndcalc WASM module..."
+
+# Create build directory
+mkdir -p build-wasm
+cd build-wasm
+
+# Configure with Emscripten
+emcmake cmake .. -DNDCALC_BUILD_TESTS=OFF -DNDCALC_BUILD_WASM=ON
+
+# Build
+emmake make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+
+# Copy outputs
+mkdir -p ../dist
+cp ndcalc_wasm.js ../dist/
+cp ndcalc_wasm.wasm ../dist/
+
+echo "WASM build complete! Outputs in dist/"
+echo "Generating TypeScript declarations..."
+
+# Generate TypeScript declarations
+cd ..
+node generate-types.js
+
+echo "Build complete!"

--- a/ndcalc-core/wasm/generate-types.js
+++ b/ndcalc-core/wasm/generate-types.js
@@ -1,0 +1,334 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const typeDefinitions = `/**
+ * ndcalc - n-dimensional calculus VM and automatic differentiation
+ * WASM module TypeScript declarations
+ */
+
+export enum ErrorCode {
+  OK = 0,
+  PARSE = 1,
+  INVALID_EXPR = 2,
+  EVAL = 3,
+  OUT_OF_MEMORY = 4,
+  INVALID_DIMENSION = 5,
+  NULL_POINTER = 6
+}
+
+export enum ADMode {
+  AUTO = 0,
+  FORWARD = 1,
+  FINITE_DIFF = 2
+}
+
+export interface NdcalcModule {
+  /**
+   * Create a new computation context
+   */
+  contextCreate(): number;
+
+  /**
+   * Destroy a context
+   */
+  contextDestroy(ctx: number): void;
+
+  /**
+   * Compile an expression to bytecode
+   * @param ctx Context handle
+   * @param expression Mathematical expression string
+   * @param variables Array of variable names
+   * @returns [error_code, program_handle]
+   */
+  compile(ctx: number, expression: string, variables: string[]): [ErrorCode, number];
+
+  /**
+   * Destroy a compiled program
+   */
+  programDestroy(program: number): void;
+
+  /**
+   * Evaluate expression at a point
+   * @param program Program handle
+   * @param inputs Input values (same order as variable names)
+   * @returns [error_code, result]
+   */
+  eval(program: number, inputs: number[]): [ErrorCode, number];
+
+  /**
+   * Evaluate expression at multiple points (SoA layout)
+   * @param program Program handle
+   * @param inputArrays Array of arrays, one per variable
+   * @returns [error_code, results]
+   */
+  evalBatch(program: number, inputArrays: number[][]): [ErrorCode, number[]];
+
+  /**
+   * Compute gradient using automatic differentiation
+   * @param program Program handle
+   * @param inputs Input values
+   * @returns [error_code, gradient]
+   */
+  gradient(program: number, inputs: number[]): [ErrorCode, number[]];
+
+  /**
+   * Compute Hessian matrix
+   * @param program Program handle
+   * @param inputs Input values
+   * @returns [error_code, hessian] (row-major)
+   */
+  hessian(program: number, inputs: number[]): [ErrorCode, number[]];
+
+  /**
+   * Set automatic differentiation mode
+   */
+  setADMode(ctx: number, mode: ADMode): void;
+
+  /**
+   * Set finite difference epsilon
+   */
+  setFDEpsilon(ctx: number, epsilon: number): void;
+
+  /**
+   * Get error string for error code
+   */
+  errorString(error: ErrorCode): string;
+
+  /**
+   * Get last error message from context
+   */
+  getLastErrorMessage(ctx: number): string;
+}
+
+/**
+ * Create WASM module instance
+ */
+export default function createNdcalcModule(): Promise<NdcalcModule>;
+`;
+
+// Write TypeScript declarations
+const distDir = path.join(__dirname, 'dist');
+if (!fs.existsSync(distDir)) {
+  fs.mkdirSync(distDir, { recursive: true });
+}
+
+fs.writeFileSync(path.join(distDir, 'ndcalc.d.ts'), typeDefinitions);
+
+// Write JavaScript wrapper
+const jsWrapper = `/**
+ * ndcalc WASM wrapper with TypeScript-friendly API
+ */
+
+import createNdcalcModuleRaw from './ndcalc_wasm.js';
+
+class NdcalcWrapper {
+  constructor(module) {
+    this.module = module;
+    this._stringToPtr = this._stringToPtr.bind(this);
+    this._stringArrayToPtr = this._stringArrayToPtr.bind(this);
+    this._freeStringArray = this._freeStringArray.bind(this);
+  }
+
+  _stringToPtr(str) {
+    const len = this.module.lengthBytesUTF8(str) + 1;
+    const ptr = this.module._malloc(len);
+    this.module.stringToUTF8(str, ptr, len);
+    return ptr;
+  }
+
+  _stringArrayToPtr(arr) {
+    const ptrs = arr.map(str => this._stringToPtr(str));
+    const arrayPtr = this.module._malloc(ptrs.length * 4);
+    ptrs.forEach((ptr, i) => {
+      this.module.setValue(arrayPtr + i * 4, ptr, 'i32');
+    });
+    return { arrayPtr, ptrs };
+  }
+
+  _freeStringArray({ arrayPtr, ptrs }) {
+    ptrs.forEach(ptr => this.module._free(ptr));
+    this.module._free(arrayPtr);
+  }
+
+  contextCreate() {
+    return this.module.ccall('wasm_context_create', 'number', [], []);
+  }
+
+  contextDestroy(ctx) {
+    this.module.ccall('wasm_context_destroy', null, ['number'], [ctx]);
+  }
+
+  compile(ctx, expression, variables) {
+    const exprPtr = this._stringToPtr(expression);
+    const varPtrs = this._stringArrayToPtr(variables);
+    const outProgramPtr = this.module._malloc(4);
+
+    const error = this.module.ccall(
+      'wasm_compile',
+      'number',
+      ['number', 'number', 'number', 'number', 'number'],
+      [ctx, exprPtr, variables.length, varPtrs.arrayPtr, outProgramPtr]
+    );
+
+    const program = this.module.getValue(outProgramPtr, 'i32');
+
+    this.module._free(exprPtr);
+    this._freeStringArray(varPtrs);
+    this.module._free(outProgramPtr);
+
+    return [error, program];
+  }
+
+  programDestroy(program) {
+    this.module.ccall('wasm_program_destroy', null, ['number'], [program]);
+  }
+
+  eval(program, inputs) {
+    const inputPtr = this.module._malloc(inputs.length * 8);
+    inputs.forEach((val, i) => {
+      this.module.setValue(inputPtr + i * 8, val, 'double');
+    });
+
+    const outputPtr = this.module._malloc(8);
+
+    const error = this.module.ccall(
+      'wasm_eval',
+      'number',
+      ['number', 'number', 'number', 'number'],
+      [program, inputPtr, inputs.length, outputPtr]
+    );
+
+    const result = this.module.getValue(outputPtr, 'double');
+
+    this.module._free(inputPtr);
+    this.module._free(outputPtr);
+
+    return [error, result];
+  }
+
+  evalBatch(program, inputArrays) {
+    const numVars = inputArrays.length;
+    const numPoints = inputArrays[0].length;
+
+    // Allocate SoA arrays
+    const arrayPtrs = inputArrays.map(arr => {
+      const ptr = this.module._malloc(arr.length * 8);
+      arr.forEach((val, i) => {
+        this.module.setValue(ptr + i * 8, val, 'double');
+      });
+      return ptr;
+    });
+
+    // Array of pointers
+    const arrayOfPtrsPtr = this.module._malloc(arrayPtrs.length * 4);
+    arrayPtrs.forEach((ptr, i) => {
+      this.module.setValue(arrayOfPtrsPtr + i * 4, ptr, 'i32');
+    });
+
+    const outputPtr = this.module._malloc(numPoints * 8);
+
+    const error = this.module.ccall(
+      'wasm_eval_batch',
+      'number',
+      ['number', 'number', 'number', 'number', 'number'],
+      [program, arrayOfPtrsPtr, numVars, numPoints, outputPtr]
+    );
+
+    const results = [];
+    for (let i = 0; i < numPoints; i++) {
+      results.push(this.module.getValue(outputPtr + i * 8, 'double'));
+    }
+
+    arrayPtrs.forEach(ptr => this.module._free(ptr));
+    this.module._free(arrayOfPtrsPtr);
+    this.module._free(outputPtr);
+
+    return [error, results];
+  }
+
+  gradient(program, inputs) {
+    const inputPtr = this.module._malloc(inputs.length * 8);
+    inputs.forEach((val, i) => {
+      this.module.setValue(inputPtr + i * 8, val, 'double');
+    });
+
+    const gradientPtr = this.module._malloc(inputs.length * 8);
+
+    const error = this.module.ccall(
+      'wasm_gradient',
+      'number',
+      ['number', 'number', 'number', 'number'],
+      [program, inputPtr, inputs.length, gradientPtr]
+    );
+
+    const gradient = [];
+    for (let i = 0; i < inputs.length; i++) {
+      gradient.push(this.module.getValue(gradientPtr + i * 8, 'double'));
+    }
+
+    this.module._free(inputPtr);
+    this.module._free(gradientPtr);
+
+    return [error, gradient];
+  }
+
+  hessian(program, inputs) {
+    const n = inputs.length;
+    const inputPtr = this.module._malloc(n * 8);
+    inputs.forEach((val, i) => {
+      this.module.setValue(inputPtr + i * 8, val, 'double');
+    });
+
+    const hessianPtr = this.module._malloc(n * n * 8);
+
+    const error = this.module.ccall(
+      'wasm_hessian',
+      'number',
+      ['number', 'number', 'number', 'number'],
+      [program, inputPtr, n, hessianPtr]
+    );
+
+    const hessian = [];
+    for (let i = 0; i < n * n; i++) {
+      hessian.push(this.module.getValue(hessianPtr + i * 8, 'double'));
+    }
+
+    this.module._free(inputPtr);
+    this.module._free(hessianPtr);
+
+    return [error, hessian];
+  }
+
+  setADMode(ctx, mode) {
+    this.module.ccall('wasm_set_ad_mode', null, ['number', 'number'], [ctx, mode]);
+  }
+
+  setFDEpsilon(ctx, epsilon) {
+    this.module.ccall('wasm_set_fd_epsilon', null, ['number', 'number'], [ctx, epsilon]);
+  }
+
+  errorString(error) {
+    const ptr = this.module.ccall('wasm_error_string', 'number', ['number'], [error]);
+    return this.module.UTF8ToString(ptr);
+  }
+
+  getLastErrorMessage(ctx) {
+    const ptr = this.module.ccall('wasm_get_last_error_message', 'number', ['number'], [ctx]);
+    return this.module.UTF8ToString(ptr);
+  }
+}
+
+export default async function createNdcalcModule() {
+  const module = await createNdcalcModuleRaw();
+  return new NdcalcWrapper(module);
+}
+
+export { ErrorCode, ADMode } from './ndcalc';
+`;
+
+fs.writeFileSync(path.join(distDir, 'index.js'), jsWrapper);
+
+console.log('TypeScript declarations generated in dist/ndcalc.d.ts');
+console.log('JavaScript wrapper generated in dist/index.js');

--- a/ndcalc-core/wasm/wasm_bindings.cpp
+++ b/ndcalc-core/wasm/wasm_bindings.cpp
@@ -1,0 +1,89 @@
+#include "ndcalc/api.h"
+#include <emscripten/emscripten.h>
+
+// Export all C API functions for WASM
+extern "C" {
+
+EMSCRIPTEN_KEEPALIVE
+ndcalc_context_handle wasm_context_create() {
+    return ndcalc_context_create();
+}
+
+EMSCRIPTEN_KEEPALIVE
+void wasm_context_destroy(ndcalc_context_handle ctx) {
+    ndcalc_context_destroy(ctx);
+}
+
+EMSCRIPTEN_KEEPALIVE
+ndcalc_error_t wasm_compile(
+    ndcalc_context_handle ctx,
+    const char* expression,
+    size_t num_variables,
+    const char* const* variable_names,
+    ndcalc_program_handle* out_program) {
+    return ndcalc_compile(ctx, expression, num_variables, variable_names, out_program);
+}
+
+EMSCRIPTEN_KEEPALIVE
+void wasm_program_destroy(ndcalc_program_handle program) {
+    ndcalc_program_destroy(program);
+}
+
+EMSCRIPTEN_KEEPALIVE
+ndcalc_error_t wasm_eval(
+    ndcalc_program_handle program,
+    const double* inputs,
+    size_t num_inputs,
+    double* output) {
+    return ndcalc_eval(program, inputs, num_inputs, output);
+}
+
+EMSCRIPTEN_KEEPALIVE
+ndcalc_error_t wasm_eval_batch(
+    ndcalc_program_handle program,
+    const double* const* input_arrays,
+    size_t num_variables,
+    size_t num_points,
+    double* output_array) {
+    return ndcalc_eval_batch(program, input_arrays, num_variables, num_points, output_array);
+}
+
+EMSCRIPTEN_KEEPALIVE
+ndcalc_error_t wasm_gradient(
+    ndcalc_program_handle program,
+    const double* inputs,
+    size_t num_inputs,
+    double* gradient_out) {
+    return ndcalc_gradient(program, inputs, num_inputs, gradient_out);
+}
+
+EMSCRIPTEN_KEEPALIVE
+ndcalc_error_t wasm_hessian(
+    ndcalc_program_handle program,
+    const double* inputs,
+    size_t num_inputs,
+    double* hessian_out) {
+    return ndcalc_hessian(program, inputs, num_inputs, hessian_out);
+}
+
+EMSCRIPTEN_KEEPALIVE
+void wasm_set_ad_mode(ndcalc_context_handle ctx, ndcalc_ad_mode_t mode) {
+    ndcalc_set_ad_mode(ctx, mode);
+}
+
+EMSCRIPTEN_KEEPALIVE
+void wasm_set_fd_epsilon(ndcalc_context_handle ctx, double epsilon) {
+    ndcalc_set_fd_epsilon(ctx, epsilon);
+}
+
+EMSCRIPTEN_KEEPALIVE
+const char* wasm_error_string(ndcalc_error_t error) {
+    return ndcalc_error_string(error);
+}
+
+EMSCRIPTEN_KEEPALIVE
+const char* wasm_get_last_error_message(ndcalc_context_handle ctx) {
+    return ndcalc_get_last_error_message(ctx);
+}
+
+} // extern "C"


### PR DESCRIPTION
## Summary

Implements the **ndcalc-core** calculus VM and automatic differentiation module per the HyperViz program briefing. This provides the foundation for user-defined scalar/vector field evaluation, gradient computation, and Hessian analysis.

### Core Components

- **Expression Parser**: Recursive descent parser supporting variables, binary/unary operators, and mathematical functions
- **Bytecode Compiler**: AST-to-bytecode compilation with 15+ stack-based opcodes
- **Virtual Machine**: Efficient evaluation engine with error handling and batch processing
- **Automatic Differentiation**: Forward-mode AD using dual numbers for exact gradients and Hessians
- **Finite Differences**: Numerical differentiation fallback with configurable epsilon
- **C API**: Clean C interface in `include/ndcalc/api.h` for native integration

### Features

- Supports operators: `+`, `-`, `*`, `/`, `^` (power)
- Supports functions: `sin`, `cos`, `tan`, `exp`, `log`, `sqrt`, `abs`, `pow`
- Batch evaluation with Structure-of-Arrays (SoA) layout for performance
- Gradient computation via forward-mode AD or central differences
- Hessian computation for second-order analysis
- Complete error handling with descriptive messages

### Testing

Comprehensive native test suite covering:
- Parser tokenization and AST construction
- VM evaluation correctness
- Automatic differentiation accuracy
- Full C API functionality

All tests validate results with numerical tolerance checks.

### WASM Export

- Emscripten bindings with memory-safe wrapper
- TypeScript declarations for type-safe browser integration
- Build script (`wasm/build.sh`) generating `.wasm`, `.js`, and `.d.ts` outputs
- JavaScript wrapper with ergonomic API

### Integration Points

Per the HyperViz architecture:
- `ndvis-web` will consume WASM module for function evaluation in browser
- `ndvis-core` can link against static library for native computations
- Headless renderer can use C API for batch field evaluation
- UI panels will call gradient/Hessian APIs for tangent plane and curvature viz

### Test Plan

- [x] Build native library with CMake
- [x] Run test suite with `ctest`
- [x] Validate parser on complex expressions
- [x] Verify VM batch evaluation with SoA inputs
- [x] Check AD gradient computation against analytical derivatives
- [x] Test WASM build script (requires Emscripten)
- [ ] Integrate with ndvis-web WASM adapter
- [ ] Add CI workflow for automated testing

### Files Changed

- 25 new files, 2991+ lines
- Headers in `ndcalc-core/include/ndcalc/`
- Implementation in `ndcalc-core/src/`
- Tests in `ndcalc-core/tests/`
- WASM bindings in `ndcalc-core/wasm/`